### PR TITLE
#27614 store db in state on save when no db state

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -816,6 +816,10 @@ class Model(six.with_metaclass(ModelBase)):
         is used by fixture loading.
         """
         using = using or router.db_for_write(self.__class__, instance=self)
+        # The database is not stored yet if it is already present on another
+        # database and may need to be read before it is saved again.
+        if not self._state.db:
+            self._state.db = using
         assert not (force_insert and (force_update or update_fields))
         assert update_fields is None or len(update_fields) > 0
         cls = origin = self.__class__

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -816,8 +816,9 @@ class Model(six.with_metaclass(ModelBase)):
         is used by fixture loading.
         """
         using = using or router.db_for_write(self.__class__, instance=self)
-        # The database is not stored yet if it is already present on another
-        # database and may need to be read before it is saved again.
+        # The database the instance will be saved on is not stored yet if it
+        # was previously saved to another database. This allows Django to read
+        # the old instance prior to saving.
         if not self._state.db:
             self._state.db = using
         assert not (force_insert and (force_update or update_fields))


### PR DESCRIPTION
Addresses a lot of the issues I'm having with multi db scenarios and not having access to the specific DB on save in the various functions throughout the save cycle which are not passed the using value.